### PR TITLE
Always repeat date from the original due date, not from the snoozed one

### DIFF
--- a/dontforget/models.py
+++ b/dontforget/models.py
@@ -136,7 +136,7 @@ class Alarm(SurrogatePK, Model):
 
         An unseen alarm will only be created if there is a repetition, and if the chore is active.
 
-        :param AlarmState desired_state: The desired state for the current alarm, before repetition.
+        :param str desired_state: The desired state for the current alarm, before repetition.
         :param str snooze_repetition: Snooze repetition chosen by the user.
         :return: The current alarm if none created, or the newly created (and unseen) alarm instance.
         :rtype: Alarm

--- a/migrations/versions/a2de422d22b8_original_at.py
+++ b/migrations/versions/a2de422d22b8_original_at.py
@@ -1,0 +1,23 @@
+"""Add original_at date to the alarm.
+
+Revision ID: a2de422d22b8
+Revises: 250e5b590f7
+Create Date: 2017-01-06 12:26:48.916280
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a2de422d22b8'
+down_revision = '250e5b590f7'
+
+
+def upgrade():
+    """Upgrade the database."""
+    op.add_column('alarm', sa.Column('original_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    """Downgrade the database."""
+    with op.batch_alter_table('alarm') as batch_op:
+        batch_op.drop_column('original_at')

--- a/tests/test_chore.py
+++ b/tests/test_chore.py
@@ -2,8 +2,6 @@
 """Test chores."""
 from datetime import datetime, timedelta
 
-import pytest
-
 from dontforget.cron import spawn_alarms
 from dontforget.models import AlarmState, Chore
 from tests.factories import NEXT_WEEK, TODAY, YESTERDAY, AlarmFactory, ChoreFactory
@@ -159,7 +157,6 @@ def test_daily_chore_from_completed(db):
     assert spawn_alarms() == 0
 
 
-@pytest.mark.xfail(reason='Bug not fixed yet')
 def test_snooze_from_original_due_date(db):
     """When you snooze a chore and then complete it later, the original date should get the repetition."""
     ten_oclock = TODAY.replace(hour=10, minute=0, second=0, microsecond=0)
@@ -168,16 +165,34 @@ def test_snooze_from_original_due_date(db):
     """:type: dontforget.models.Alarm"""
     db.session.commit()
 
-    assert len(chore.alarms) == 1
-    last_alarm = chore.alarms[len(chore.alarms) - 1]
+    def get_last_alarm(expected_len):
+        """Get the last alarm from the chore.
+
+        :rtype: dontforget.models.Alarm
+        """
+        assert len(chore.alarms) == expected_len
+        return chore.alarms[expected_len - 1]
+
+    last_alarm = get_last_alarm(1)
     assert last_alarm.next_at == ten_oclock
 
-    last_alarm.snooze('5 minutes')
-    assert len(chore.alarms) == 2
-    last_alarm = chore.alarms[len(chore.alarms) - 1]
+    # Snooze several times.
+    for index, minutes in enumerate([2, 1, 4]):
+        last_alarm.snooze('{} hours'.format(minutes))
+        last_alarm = get_last_alarm(2 + index)
 
+    # Skip one day.
+    last_alarm.skip()
+    last_alarm = get_last_alarm(5)
+
+    # Snooze again several times.
+    for index, minutes in enumerate([10, 15, 30, 10]):
+        last_alarm.snooze('{} minutes'.format(minutes))
+        last_alarm = get_last_alarm(6 + index)
+
+    # Finally complete the chore the next day.
     last_alarm.complete()
-    assert len(chore.alarms) == 3
+    last_alarm = get_last_alarm(10)
 
-    # The next alarm should be the next day at 10:00, and not the snooze time
-    assert last_alarm.next_at == ten_oclock + timedelta(days=1)
+    # The next alarm should be 2 days later at 10:00, and not the snooze time.
+    assert last_alarm.next_at == ten_oclock + timedelta(days=2)

--- a/tests/test_chore.py
+++ b/tests/test_chore.py
@@ -184,6 +184,7 @@ def test_snooze_from_original_due_date(db):
     # Skip one day.
     last_alarm.skip()
     last_alarm = get_last_alarm(5)
+    assert last_alarm.next_at == ten_oclock + timedelta(days=1)
 
     # Snooze again several times.
     for index, minutes in enumerate([10, 15, 30, 10]):
@@ -193,6 +194,4 @@ def test_snooze_from_original_due_date(db):
     # Finally complete the chore the next day.
     last_alarm.complete()
     last_alarm = get_last_alarm(10)
-
-    # The next alarm should be 2 days later at 10:00, and not the snooze time.
     assert last_alarm.next_at == ten_oclock + timedelta(days=2)


### PR DESCRIPTION
When you snooze a chore and then complete it later, the snooze date is the one that get the repetition.
- [x] Make a test to reproduce this bug
- [x] Create a daily chore at 10:00
- [x] Snooze it for 3 hours
- [x] Complete it after snoozing
- [x] The next alarm should be the next day at 10:00, and not the snooze time
- [x] Solve the bug
