### PR TITLE
Fix human readable format for dates

### DIFF
--- a/dontforget/cron.py
+++ b/dontforget/cron.py
@@ -54,7 +54,7 @@ def display_unseen_alarms(right_now=None):
     from dontforget.ui import show_dialog
 
     if not right_now:
-        right_now = datetime.now()
+        right_now = datetime.utcnow()
 
     count = 0
     # pylint: disable=no-member

--- a/dontforget/models.py
+++ b/dontforget/models.py
@@ -117,9 +117,9 @@ class Alarm(SurrogatePK, Model):
     @property
     def one_line(self):
         """Represent the alarm in one line."""
-        next_at = arrow.get(self.next_at)
+        due_at = arrow.get(self.original_at or self.next_at).to('local')
         return '{title} \u231b {due} ({human})'.format(
-            title=self.chore.title, due=next_at.format('ddd MMM DD, YYYY HH:MM'), human=next_at.humanize())
+            title=self.chore.title, due=due_at.format('ddd MMM DD, YYYY HH:mm'), human=due_at.humanize())
 
     @classmethod
     def create_unseen(cls, chore_id, next_at, last_snooze=None, **kwargs):

--- a/dontforget/repetition.py
+++ b/dontforget/repetition.py
@@ -66,7 +66,7 @@ def next_dates(natural_language_repetition, reference_date=None, count=1):
     if not natural_language_repetition:
         return None
     if not reference_date:
-        reference_date = datetime.now()
+        reference_date = datetime.utcnow()
 
     mapping = FREQUENCY_MAPPING.get(natural_language_repetition.lower())
     if mapping:

--- a/dontforget/ui/telegram_bot.py
+++ b/dontforget/ui/telegram_bot.py
@@ -85,7 +85,7 @@ class ChoreBot(ChatHandler):
 
     def show_overdue_alarms(self):
         """Show overdue alarms on a chat message."""
-        right_now = datetime.now()
+        right_now = datetime.utcnow()
         query = Alarm.query.filter(  # pylint: disable=no-member
             Alarm.current_state == AlarmState.UNSEEN, Alarm.next_at <= right_now).order_by(Alarm.next_at.desc())
         chores = []

--- a/dontforget/ui/telegram_bot.py
+++ b/dontforget/ui/telegram_bot.py
@@ -168,8 +168,9 @@ class ChoreBot(ChatHandler):
 
     def on__idle(self, event):
         """Close the conversation when idle for some time."""
-        self.send_message("It looks like you're busy now. I hope we can talk again some day, {}.".format(
-            self.msg['from']['first_name']))
+        if self.next_step:
+            self.send_message("It looks like you're busy now. Let's talk later, {}.".format(
+                self.msg['from']['first_name']))
         self.close()  # pylint: disable=no-member
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,7 +13,7 @@ from dontforget.user.models import User
 
 fake = Faker()  # pylint: disable=invalid-name
 
-TODAY = datetime.now()
+TODAY = datetime.utcnow()
 NEXT_WEEK = TODAY + timedelta(days=7)
 LAST_WEEK = TODAY - timedelta(days=7)
 YESTERDAY = TODAY - timedelta(days=1)

--- a/tests/test_chore.py
+++ b/tests/test_chore.py
@@ -131,7 +131,7 @@ def test_daily_chore_from_completed(db):
     # Simulate as the chore were completed some time from now.
     # Automated tests are too fast, the timestamps are almost the same, and that interferes with the results.
     chore.alarms[0].current_state = AlarmState.COMPLETED
-    chore.alarms[0].updated_at = datetime.now() + timedelta(seconds=5)
+    chore.alarms[0].updated_at = datetime.utcnow() + timedelta(seconds=5)
     chore.alarms[0].save()
 
     # Spawn one alarm for the next day.
@@ -141,7 +141,7 @@ def test_daily_chore_from_completed(db):
 
     # Simulate as the chore were completed again, some time from now.
     chore.alarms[1].current_state = AlarmState.COMPLETED
-    chore.alarms[1].updated_at = datetime.now() + timedelta(seconds=10)
+    chore.alarms[1].updated_at = datetime.utcnow() + timedelta(seconds=10)
     chore.alarms[1].save()
 
     # Spawn one alarm for the next day.

--- a/tests/test_repetition.py
+++ b/tests/test_repetition.py
@@ -27,8 +27,8 @@ def test_simple_patterns_with_every_each():
 
 def test_invalid_repetition():
     """Invalid repetition."""
-    assert next_dates(None, datetime.now()) is None
-    assert next_dates('something really strange', datetime.now()) is None
+    assert next_dates(None, datetime.utcnow()) is None
+    assert next_dates('something really strange', datetime.utcnow()) is None
 
 
 def test_invalid_count():


### PR DESCRIPTION
`Alarm.one_line` is probably showing UTC times, while `next_at` has a local CET time.
